### PR TITLE
feat: expose nodePoolWeight and optimise YAML formatting for NodePools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `enable_al2023` and `enable_bottlerocket` variables to toggle NodePool and EC2NodeClass for each AMI family.
 - Added support for custom UserData for both AL2023 and Bottlerocket via `al2023_userdata` and `bottlerocket_userdata`.
 - Added `topologySpreadConstraints` and `extraRequirements` support for AL2023 and Bottlerocket NodePools.
-- Integrated `nodePoolWeight` into NodePool specifications.
+- Integrated `nodePoolWeight` into NodePool specifications and exposed them as configurable Terraform variables.
+- Improved YAML indentation for complex variables in `main.tf` to prevent syntax errors.
 - Updated Bottlerocket AMI selector to use `bottlerocket@v1` alias.
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 This module deploys Karpenter on EKS, using Fargate. This makes it possible to operate
 an EKS cluster without managed node groups (MNGs).
 
+## Usage
+
+This module can be used to deploy Karpenter with support for both Amazon Linux 2023 (AL2023) and Bottlerocket nodes. You can customise the NodePools using the provided variables to suit your workload requirements.
+
+### Key Configuration Options
+
+- **NodePool Weights:** Use `al2023_node_pool_weight` and `bottlerocket_node_pool_weight` to control scheduling priority across different AMI families.
+- **AMI Families:** Enable or disable AMI families using `enable_al2023` and `enable_bottlerocket`.
+- **Custom UserData:** Provide custom bootstrap logic via `al2023_userdata` and `bottlerocket_userdata`.
+- **Scheduling Constraints:** Define `topologySpreadConstraints` and `extraRequirements` as YAML strings for fine-grained control over pod placement.
+- **Instance Exclusion:** Exclude specific instance sizes (e.g., nano, micro) using the `excluded_instance_sizes` variable.
+
 ## Changes
 
 Changes to this module are captured in the [CHANGELOG](./CHANGELOG.md).

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -36,5 +36,3 @@ bottlerocket:
 
 al2023UserData: ""
 bottlerocketUserData: ""
-
-replicas: 1

--- a/main.tf
+++ b/main.tf
@@ -89,14 +89,22 @@ expireAfter: ${var.expire_after}
 imageGCHighThresholdPercent: ${var.image_gc_high_threshold_percent}
 imageGCLowThresholdPercent: ${var.image_gc_low_threshold_percent}
 
+nodePoolWeight:
+  al2023: ${var.al2023_node_pool_weight}
+  bottlerocket: ${var.bottlerocket_node_pool_weight}
+
 al2023:
   enabled: ${var.enable_al2023}
-  topologySpreadConstraints: ${var.al2023_topology_spread_constraints}
-  extraRequirements: ${var.al2023_extra_requirements}
+  topologySpreadConstraints:
+${indent(4, var.al2023_topology_spread_constraints)}
+  extraRequirements:
+${indent(4, var.al2023_extra_requirements)}
 bottlerocket:
   enabled: ${var.enable_bottlerocket}
-  topologySpreadConstraints: ${var.bottlerocket_topology_spread_constraints}
-  extraRequirements: ${var.bottlerocket_extra_requirements}
+  topologySpreadConstraints:
+${indent(4, var.bottlerocket_topology_spread_constraints)}
+  extraRequirements:
+${indent(4, var.bottlerocket_extra_requirements)}
 
 al2023UserData: |-
 ${indent(2, var.al2023_userdata)}

--- a/variables.tf
+++ b/variables.tf
@@ -131,3 +131,15 @@ variable "bottlerocket_extra_requirements" {
   type        = string
   default     = "[]"
 }
+
+variable "al2023_node_pool_weight" {
+  description = "Weight for AL2023 NodePool to control scheduling priority"
+  type        = number
+  default     = 10
+}
+
+variable "bottlerocket_node_pool_weight" {
+  description = "Weight for Bottlerocket NodePool to control scheduling priority"
+  type        = number
+  default     = 20
+}


### PR DESCRIPTION
This PR was generated by Aerith.

**Slack Context:** [Link to Slack Thread](https://footprintitsolutions.slack.com/archives/C08PSC7ERL2/p1774767912.882729)

**Task ID:** 0f201c8a-fb29-441c-a75c-a1d2275b4e6b

### Description

This PR addresses an omission in the recent implementation of node pool weights and improves the YAML formatting for complex variables.

Key changes:
- Exposed  al2023_node_pool_weight  and  bottlerocket_node_pool_weight  as Terraform variables.
- Passed the weights to the Helm release in  main.tf .
- Optimised YAML indentation for  topologySpreadConstraints  and  extraRequirements  to prevent syntax errors with multi-line inputs.
- Removed the unused  replicas  variable from the Helm values.
- Updated documentation and changelog accordingly.

This PR was generated by Aerith.

**Slack Context:** [Link to Slack Thread](https://footprintitsolutions.slack.com/archives/C08PSC7ERL2/p1774767912882729)

**Task ID:** 0f201c8a-fb29-441c-a75c-a1d2275b4e6b