### PR TITLE
Fix set to list for excluded instance sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-03-29
+
 ### Added
 
 - Introduced `excluded_instance_sizes` variable to allow configurable exclusion of AWS instance sizes (e.g. nano, micro, small, medium) from NodePools.
@@ -16,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `topologySpreadConstraints` and `extraRequirements` support for AL2023 and Bottlerocket NodePools.
 - Integrated `nodePoolWeight` into NodePool specifications.
 - Updated Bottlerocket AMI selector to use `bottlerocket@v1` alias.
+
+### Fixed
+
+- Fixed the `excluded_instance_sizes` variable by using `tolist()` to ensure correct type conversion.
 
 ### Removed
 

--- a/main.tf
+++ b/main.tf
@@ -73,11 +73,11 @@ resource "helm_release" "extras" {
   set_list = [
     {
       name  = "allowedArch"
-      value = var.allowed_arch
+      value = tolist(var.allowed_arch)
     },
     {
       name  = "excludedInstanceSizes"
-      value = var.excluded_instance_sizes
+      value = tolist(var.excluded_instance_sizes)
     }
   ]
 


### PR DESCRIPTION
This pull request introduces a new patch release (v2.2.1) that adds a configurable variable for excluding AWS instance sizes in NodePools and fixes a type conversion issue related to this feature. The main focus is on improving the flexibility and correctness of instance size exclusions.

**Feature Additions:**

* Added a new `excluded_instance_sizes` variable to allow users to specify which AWS instance sizes (e.g., nano, micro, small, medium) should be excluded from NodePools.

**Bug Fixes:**

* Fixed the `excluded_instance_sizes` variable by applying `tolist()` to ensure correct type conversion, preventing potential errors when passing this variable to resources. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR22-R25) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL76-R80)
* Applied `tolist()` to the `allowed_arch` variable to ensure consistent type handling in the `helm_release` resource.