### PR TITLE
Implement node interruption handling and optimise IAM policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-03-30
+
+### Added
+
+- Added an SQS queue and EventBridge rules to support Karpenter native interruption handling (Spot interruptions, rebalance recommendations, etc.).
+- Added resource-level tagging conditions and regional restrictions to EC2 and SSM permissions.
+
+### Changed
+
+- Upgraded Bottlerocket AMI selector alias from `v1` to `latest` in `EC2NodeClass`.
+- Refactored IAM policy for the Karpenter controller to follow the principle of least privilege.
+- Broken down monolithic IAM statements into scoped actions for resource discovery and node lifecycle management.
+
 ## [2.2.1] - 2026-03-29
 
 ### Added
@@ -32,7 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add metadata options for ec2nodeclass with override for httpPutResponseHopLimit to allow access to Instance Metadata Service (IMDS) from EKS pods. 
+- Add metadata options for ec2nodeclass with override for httpPutResponseHopLimit to allow access to Instance Metadata Service (IMDS) from EKS pods.
 
 ## [2.1.1] - 2026-01-14
 

--- a/helm/templates/ec2nodeclass.yaml
+++ b/helm/templates/ec2nodeclass.yaml
@@ -45,7 +45,7 @@ metadata:
 spec:
   amiFamily: Bottlerocket
   amiSelectorTerms:
-    - alias: bottlerocket@v1
+    - alias: bottlerocket@latest
   blockDeviceMappings:
     {{- range $deviceName, $config := index .Values.blockDeviceMappings "bottlerocket" }}
     - deviceName: {{ $deviceName | quote }}

--- a/iam.tf
+++ b/iam.tf
@@ -30,73 +30,247 @@ resource "aws_iam_role" "this" {
 }
 
 data "aws_iam_policy_document" "policy" {
+  # KarpenterControllerResourceDiscoveryPolicy
   statement {
-    sid    = "Karpenter"
+    sid    = "AllowRegionalReadActions"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeCapacityReservations",
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = [var.aws_region]
+    }
+  }
+
+  statement {
+    sid    = "AllowSSMReadActions"
     effect = "Allow"
     actions = [
       "ssm:GetParameter",
-      "ec2:DescribeImages",
-      "ec2:RunInstances",
-      "ec2:DescribeSubnets",
-      "ec2:DescribeSecurityGroups",
-      "ec2:DescribeLaunchTemplates",
-      "ec2:DescribeInstances",
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeInstanceTypeOfferings",
-      "ec2:DeleteLaunchTemplate",
-      "ec2:CreateTags",
-      "ec2:CreateLaunchTemplate",
-      "ec2:CreateFleet",
-      "ec2:DescribeSpotPriceHistory",
+    ]
+    resources = ["arn:aws:ssm:${var.aws_region}::parameter/aws/service/*"]
+  }
+
+  statement {
+    sid    = "AllowPricingReadActions"
+    effect = "Allow"
+    actions = [
       "pricing:GetProducts",
-      "iam:CreateServiceLinkedRole",
     ]
     resources = ["*"]
   }
 
+  # KarpenterControllerNodeLifecyclePolicy
   statement {
-    sid    = "ConditionalEC2Termination"
+    sid    = "AllowScopedEC2InstanceAccessActions"
     effect = "Allow"
     actions = [
-      "ec2:TerminateInstances"
+      "ec2:RunInstances",
+      "ec2:CreateFleet",
     ]
-    resources = ["*"]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}::image/*",
+      "arn:aws:ec2:${var.aws_region}::snapshot/*",
+      "arn:aws:ec2:${var.aws_region}:*:security-group/*",
+      "arn:aws:ec2:${var.aws_region}:*:subnet/*",
+      "arn:aws:ec2:${var.aws_region}:*:capacity-reservation/*",
+    ]
+  }
+
+  statement {
+    sid    = "AllowScopedEC2LaunchTemplateAccessActions"
+    effect = "Allow"
+    actions = [
+      "ec2:RunInstances",
+      "ec2:CreateFleet",
+    ]
+    resources = ["arn:aws:ec2:${var.aws_region}:*:launch-template/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
     condition {
       test     = "StringLike"
-      variable = "ec2:ResourceTag/karpenter.sh/nodepool"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
       values   = ["*"]
     }
   }
 
   statement {
-    sid    = "PassNodeIAMRole"
+    sid    = "AllowScopedEC2InstanceActionsWithTags"
     effect = "Allow"
     actions = [
-      "iam:PassRole"
+      "ec2:RunInstances",
+      "ec2:CreateFleet",
+      "ec2:CreateLaunchTemplate",
     ]
-    resources = ["arn:aws:iam::${var.aws_account_id}:role/eks-node"]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:*:fleet/*",
+      "arn:aws:ec2:${var.aws_region}:*:instance/*",
+      "arn:aws:ec2:${var.aws_region}:*:volume/*",
+      "arn:aws:ec2:${var.aws_region}:*:network-interface/*",
+      "arn:aws:ec2:${var.aws_region}:*:launch-template/*",
+      "arn:aws:ec2:${var.aws_region}:*:spot-instances-request/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
   }
 
   statement {
-    sid    = "EKSClusterEndpointLookup"
+    sid    = "AllowScopedResourceCreationTagging"
     effect = "Allow"
     actions = [
-      "eks:DescribeCluster"
+      "ec2:CreateTags",
     ]
-    resources = ["arn:aws:eks:${var.aws_region}:${var.aws_account_id}:cluster/${var.cluster_name}"]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:*:fleet/*",
+      "arn:aws:ec2:${var.aws_region}:*:instance/*",
+      "arn:aws:ec2:${var.aws_region}:*:volume/*",
+      "arn:aws:ec2:${var.aws_region}:*:network-interface/*",
+      "arn:aws:ec2:${var.aws_region}:*:launch-template/*",
+      "arn:aws:ec2:${var.aws_region}:*:spot-instances-request/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "ec2:CreateAction"
+      values = [
+        "RunInstances",
+        "CreateFleet",
+        "CreateLaunchTemplate",
+      ]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:RequestTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  statement {
+    sid    = "AllowScopedResourceTagging"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateTags",
+    ]
+    resources = ["arn:aws:ec2:${var.aws_region}:*:instance/*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+    condition {
+      test     = "StringEqualsIfExists"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
+    }
+    condition {
+      test     = "ForAllValues:StringEquals"
+      variable = "aws:TagKeys"
+      values = [
+        "eks:eks-cluster-name",
+        "karpenter.sh/nodeclaim",
+        "Name",
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowScopedDeletion"
+    effect = "Allow"
+    actions = [
+      "ec2:TerminateInstances",
+      "ec2:DeleteLaunchTemplate",
+    ]
+    resources = [
+      "arn:aws:ec2:${var.aws_region}:*:instance/*",
+      "arn:aws:ec2:${var.aws_region}:*:launch-template/*",
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
+      values   = ["owned"]
+    }
+    condition {
+      test     = "StringLike"
+      variable = "aws:ResourceTag/karpenter.sh/nodepool"
+      values   = ["*"]
+    }
+  }
+
+  # KarpenterControllerIAMIntegrationPolicy
+  statement {
+    sid    = "AllowPassingInstanceRole"
+    effect = "Allow"
+    actions = [
+      "iam:PassRole",
+    ]
+    resources = ["arn:aws:iam::${var.aws_account_id}:role/eks-node"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values = [
+        "ec2.amazonaws.com",
+      ]
+    }
   }
 
   statement {
     sid    = "AllowScopedInstanceProfileCreationActions"
     effect = "Allow"
     actions = [
-      "iam:CreateInstanceProfile"
+      "iam:CreateInstanceProfile",
     ]
-    resources = ["*"]
+    resources = ["arn:aws:iam::${var.aws_account_id}:instance-profile/*"]
     condition {
       test     = "StringEquals"
       variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
       values   = ["owned"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
     }
     condition {
       test     = "StringEquals"
@@ -114,9 +288,9 @@ data "aws_iam_policy_document" "policy" {
     sid    = "AllowScopedInstanceProfileTagActions"
     effect = "Allow"
     actions = [
-      "iam:TagInstanceProfile"
+      "iam:TagInstanceProfile",
     ]
-    resources = ["*"]
+    resources = ["arn:aws:iam::${var.aws_account_id}:instance-profile/*"]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
@@ -131,6 +305,11 @@ data "aws_iam_policy_document" "policy" {
       test     = "StringEquals"
       variable = "aws:RequestTag/kubernetes.io/cluster/${var.cluster_name}"
       values   = ["owned"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestTag/eks:eks-cluster-name"
+      values   = [var.cluster_name]
     }
     condition {
       test     = "StringEquals"
@@ -157,7 +336,7 @@ data "aws_iam_policy_document" "policy" {
       "iam:RemoveRoleFromInstanceProfile",
       "iam:DeleteInstanceProfile",
     ]
-    resources = ["*"]
+    resources = ["arn:aws:iam::${var.aws_account_id}:instance-profile/*"]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceTag/kubernetes.io/cluster/${var.cluster_name}"
@@ -183,6 +362,28 @@ data "aws_iam_policy_document" "policy" {
       "iam:ListInstanceProfiles",
     ]
     resources = ["*"]
+  }
+
+  # KarpenterControllerEKSIntegrationPolicy
+  statement {
+    sid    = "AllowAPIServerEndpointDiscovery"
+    effect = "Allow"
+    actions = [
+      "eks:DescribeCluster",
+    ]
+    resources = ["arn:aws:eks:${var.aws_region}:${var.aws_account_id}:cluster/${var.cluster_name}"]
+  }
+
+  # KarpenterControllerInterruptionPolicy
+  statement {
+    sid    = "AllowInterruptionQueueActions"
+    effect = "Allow"
+    actions = [
+      "sqs:DeleteMessage",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+    ]
+    resources = [aws_sqs_queue.karpenter.arn]
   }
 }
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 terraform {
   required_providers {
+    aws        = {}
     helm       = {}
     kubernetes = {}
   }
@@ -24,6 +25,10 @@ resource "helm_release" "this" {
     {
       name  = "settings.clusterName"
       value = var.cluster_name
+    },
+    {
+      name  = "settings.interruptionQueue"
+      value = aws_sqs_queue.karpenter.name
     }
   ], [
     for gate, enabled in var.feature_gates : {

--- a/sqs.tf
+++ b/sqs.tf
@@ -1,0 +1,59 @@
+resource "aws_sqs_queue" "karpenter" {
+  name                      = var.cluster_name
+  message_retention_seconds = 300
+  sqs_managed_sse_enabled   = true
+}
+
+resource "aws_sqs_queue_policy" "karpenter" {
+  queue_url = aws_sqs_queue.karpenter.id
+
+  policy = data.aws_iam_policy_document.sqs_policy.json
+}
+
+data "aws_iam_policy_document" "sqs_policy" {
+  statement {
+    sid    = "EC2InterruptionPolicy"
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["events.amazonaws.com", "sqs.amazonaws.com"]
+    }
+
+    actions   = ["sqs:SendMessage"]
+    resources = [aws_sqs_queue.karpenter.arn]
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "rules" {
+  for_each = {
+    scheduled_change = {
+      description   = "Karpenter interrupt - AWS Health Event"
+      event_pattern = { source = ["aws.health"], detail-type = ["AWS Health Event"] }
+    }
+    spot_interruption = {
+      description   = "Karpenter interrupt - EC2 Spot Instance Interruption Warning"
+      event_pattern = { source = ["aws.ec2"], detail-type = ["EC2 Spot Instance Interruption Warning"] }
+    }
+    rebalance_recommendation = {
+      description   = "Karpenter interrupt - EC2 Instance Rebalance Recommendation"
+      event_pattern = { source = ["aws.ec2"], detail-type = ["EC2 Instance Rebalance Recommendation"] }
+    }
+    instance_state_change = {
+      description   = "Karpenter interrupt - EC2 Instance State-change Notification"
+      event_pattern = { source = ["aws.ec2"], detail-type = ["EC2 Instance State-change Notification"] }
+    }
+  }
+
+  name          = "${var.cluster_name}-${each.key}"
+  description   = each.value.description
+  event_pattern = jsonencode(each.value.event_pattern)
+}
+
+resource "aws_cloudwatch_event_target" "targets" {
+  for_each = aws_cloudwatch_event_rule.rules
+
+  rule      = each.value.name
+  target_id = "KarpenterInterruptionQueueTarget"
+  arn       = aws_sqs_queue.karpenter.arn
+}


### PR DESCRIPTION
This pull request introduces native node interruption handling for Karpenter and refactors IAM policies to follow the principle of least privilege.

Key changes include:
- Added an SQS queue and EventBridge rules to support Karpenter's native interruption handling (Spot interruptions, rebalance recommendations, etc.).
- Enhanced IAM security by adding resource-level tagging conditions and regional restrictions to EC2 and SSM permissions.
- Upgraded the Bottlerocket AMI selector alias from `v1` to `latest` in the `EC2NodeClass` template.
- Refactored the Karpenter controller's IAM policy, breaking down monolithic statements into scoped actions for better resource discovery and node lifecycle management.