### PR TITLE
feat: make Karpenter consolidation delay configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-14
+
+### Added
+
+- Added `consolidate_after` variable to allow configurable consolidation delay.
+
+### Changed
+
+- Replaced hardcoded `consolidateAfter` with a Helm value.
+- Increased the default `consolidateAfter` to 120s.
+
 ## [2.3.0] - 2026-03-30
 
 ### Added

--- a/helm/templates/nodepool.yaml
+++ b/helm/templates/nodepool.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   weight: {{ .Values.nodePoolWeight.al2023 }}
   disruption:
-    consolidateAfter: 30s
+    consolidateAfter: {{ .Values.consolidateAfter }}
     consolidationPolicy: WhenEmptyOrUnderutilized
   template:
     spec:
@@ -71,7 +71,7 @@ metadata:
 spec:
   weight: {{ .Values.nodePoolWeight.bottlerocket }}
   disruption:
-    consolidateAfter: 30s
+    consolidateAfter: {{ .Values.consolidateAfter }}
     consolidationPolicy: WhenEmptyOrUnderutilized
   template:
     spec:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,6 +25,8 @@ nodePoolWeight:
   al2023: 10
   bottlerocket: 20
 
+consolidateAfter: 120s
+
 al2023:
   enabled: true
   topologySpreadConstraints: []

--- a/main.tf
+++ b/main.tf
@@ -90,6 +90,7 @@ resource "helm_release" "extras" {
     file("${path.module}/helm/values.yaml"),
     <<-EOT
 ---
+consolidateAfter: ${var.consolidate_after}
 expireAfter: ${var.expire_after}
 imageGCHighThresholdPercent: ${var.image_gc_high_threshold_percent}
 imageGCLowThresholdPercent: ${var.image_gc_low_threshold_percent}

--- a/variables.tf
+++ b/variables.tf
@@ -32,6 +32,12 @@ variable "aws_region" {
   type        = string
 }
 
+variable "consolidate_after" {
+  description = "Controls how long Karpenter waits before consolidating nodes"
+  type        = string
+  default     = "120s"
+}
+
 variable "expire_after" {
   description = "This ensures nodes are recycled weekly, preventing the accumulation of stale images over long periods."
   type        = string


### PR DESCRIPTION
Replaced the hardcoded `consolidateAfter` value in the NodePool templates with a configurable Helm value. The default delay has been increased from 30s to 120s to reduce disruption frequency.

- Added `consolidate_after` variable to Terraform
- Added `consolidateAfter` to Helm values
- Updated `nodepool.yaml` templates to use the new variable
- Updated CHANGELOG for version 2.4.0