### PR TITLE
feat: add support for dynamic NodePool definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for multiple NodePools via the `node_pools` variable.
+- Dynamically generate NodePool resources from the `node_pools` map in the Helm chart.
+
 ## [2.4.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-04-17
+
 ### Added
 
 - Added support for multiple NodePools via the `node_pools` variable.

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,4 +4,4 @@ appVersion: "1.0.0"
 description: A Helm chart for deploying Karpenter resources
 name: karpenter-extras
 type: application
-version: 2.2.0
+version: 2.5.0-rc1

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -4,4 +4,4 @@ appVersion: "1.0.0"
 description: A Helm chart for deploying Karpenter resources
 name: karpenter-extras
 type: application
-version: 2.5.0-rc1
+version: 2.5.0

--- a/helm/templates/ec2nodeclass.yaml
+++ b/helm/templates/ec2nodeclass.yaml
@@ -1,3 +1,48 @@
+{{- range $name, $pool := .Values.nodePools }}
+---
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: {{ $name }}
+spec:
+  amiFamily: {{ default "AL2023" $pool.amiFamily }}
+  amiSelectorTerms:
+    - alias: {{ if eq (default "AL2023" $pool.amiFamily | upper) "AL2023" }}al2023@v20251007{{ else }}bottlerocket@latest{{ end }}
+  blockDeviceMappings:
+    {{- range $deviceName, $config := index $.Values.blockDeviceMappings (default "al2023" $pool.amiFamily | lower) }}
+    - deviceName: {{ $deviceName | quote }}
+      ebs:
+        deleteOnTermination: {{ default true $config.deleteOnTermination }}
+        volumeSize: {{ $config.volumeSize }}
+        volumeType: {{ default "gp3" $config.volumeType }}
+    {{- end }}
+  kubelet:
+    maxPods: 110
+  metadataOptions:
+    httpEndpoint: enabled
+    httpProtocolIPv6: disabled
+    httpPutResponseHopLimit: 2 # This is changed to enable IMDS access from containers not on the host network
+    httpTokens: required
+  {{- if eq (default "AL2023" $pool.amiFamily | upper) "AL2023" }}
+  {{- if $.Values.al2023UserData }}
+  userData: |-
+{{ $.Values.al2023UserData | indent 4 }}
+  {{- end }}
+  {{- else if eq (default "AL2023" $pool.amiFamily | upper) "BOTTLEROCKET" }}
+  {{- if $.Values.bottlerocketUserData }}
+  userData: |-
+{{ $.Values.bottlerocketUserData | indent 4 }}
+  {{- end }}
+  {{- end }}
+  role: eks-node
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ $.Values.clusterName }}
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: {{ $.Values.clusterName }}
+{{- end }}
+
 {{- if .Values.al2023.enabled }}
 ---
 apiVersion: karpenter.k8s.aws/v1

--- a/helm/templates/nodepool.yaml
+++ b/helm/templates/nodepool.yaml
@@ -1,3 +1,67 @@
+{{- range $name, $pool := .Values.nodePools }}
+---
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  labels:
+    karpenter.sh/nodepool: {{ $name }}
+  name: {{ $name }}
+spec:
+  weight: {{ default 10 $pool.weight }}
+  disruption:
+    consolidateAfter: {{ default $.Values.consolidateAfter $pool.consolidateAfter }}
+    consolidationPolicy: {{ default "WhenEmptyOrUnderutilized" $pool.consolidationPolicy }}
+  template:
+    spec:
+      expireAfter: {{ default $.Values.expireAfter $pool.expireAfter }}
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: {{ default "al2023" $pool.amiFamily | lower }}
+      kubelet:
+        imageGCHighThresholdPercent: {{ default $.Values.imageGCHighThresholdPercent $pool.imageGCHighThresholdPercent }}
+        imageGCLowThresholdPercent: {{ default $.Values.imageGCLowThresholdPercent $pool.imageGCLowThresholdPercent }}
+      {{- if $pool.taints }}
+      taints:
+        {{- toYaml $pool.taints | nindent 8 }}
+      {{- end }}
+      {{- if $pool.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml $pool.topologySpreadConstraints | nindent 8 }}
+      {{- end }}
+      requirements:
+        - key: "karpenter.k8s.aws/instance-hypervisor"
+          operator: In
+          values: ["nitro"]
+        - key: kubernetes.io/arch
+          operator: In
+          values:
+          {{- range $.Values.allowedArch }}
+            - {{ . }}
+          {{- end }}
+        - key: kubernetes.io/os
+          operator: In
+          values: ["linux"]
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand", "spot"]
+        - key: karpenter.k8s.aws/instance-size
+          operator: NotIn
+          values:
+          {{- range $.Values.excludedInstanceSizes }}
+            - {{ . }}
+          {{- end }}
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["c", "g", "m", "r"]
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["2"]
+        {{- if $pool.requirements }}
+        {{- toYaml $pool.requirements | nindent 8 }}
+        {{- end }}
+{{- end }}
+
 {{- if .Values.al2023.enabled }}
 ---
 apiVersion: karpenter.sh/v1

--- a/helm/templates/nodepool.yaml
+++ b/helm/templates/nodepool.yaml
@@ -17,7 +17,7 @@ spec:
       nodeClassRef:
         group: karpenter.k8s.aws
         kind: EC2NodeClass
-        name: {{ default "al2023" $pool.amiFamily | lower }}
+        name: {{ $name }}
       kubelet:
         imageGCHighThresholdPercent: {{ default $.Values.imageGCHighThresholdPercent $pool.imageGCHighThresholdPercent }}
         imageGCLowThresholdPercent: {{ default $.Values.imageGCLowThresholdPercent $pool.imageGCLowThresholdPercent }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -25,6 +25,8 @@ nodePoolWeight:
   al2023: 10
   bottlerocket: 20
 
+nodePools: {}
+
 consolidateAfter: 120s
 
 al2023:

--- a/main.tf
+++ b/main.tf
@@ -95,6 +95,8 @@ expireAfter: ${var.expire_after}
 imageGCHighThresholdPercent: ${var.image_gc_high_threshold_percent}
 imageGCLowThresholdPercent: ${var.image_gc_low_threshold_percent}
 
+nodePools: ${jsonencode(var.node_pools)}
+
 al2023:
   enabled: ${var.enable_al2023}
   topologySpreadConstraints: ${var.al2023_topology_spread_constraints}

--- a/variables.tf
+++ b/variables.tf
@@ -114,6 +114,12 @@ variable "enable_bottlerocket" {
   default     = true
 }
 
+variable "node_pools" {
+  description = "Map of NodePool definitions"
+  type        = any
+  default     = {}
+}
+
 variable "al2023_topology_spread_constraints" {
   description = "Topology spread constraints for AL2023 NodePool (YAML string)"
   type        = string


### PR DESCRIPTION
Implement a range loop in the Helm template to allow the creation of multiple Karpenter NodePools from a configuration map. This change adds a new `nodePools` variable to the Helm values, Terraform variables, and main manifest to provide greater flexibility in defining custom node groups beyond the default AL2023 and Bottlerocket pools.

Fixes #24