### PR TITLE
Use al2023@latest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-06-29
+
+### Changed
+
+- Replaced hardcoded al2023 version with `latest`
+
 ## [2.5.0] - 2026-04-17
 
 ### Added

--- a/helm/templates/ec2nodeclass.yaml
+++ b/helm/templates/ec2nodeclass.yaml
@@ -52,7 +52,7 @@ metadata:
 spec:
   amiFamily: AL2023
   amiSelectorTerms:
-    - alias: al2023@v20251007
+    - alias: al2023@latest
   blockDeviceMappings:
     {{- range $deviceName, $config := index .Values.blockDeviceMappings "al2023" }}
     - deviceName: {{ $deviceName | quote }}


### PR DESCRIPTION
This pull request updates the Amazon Machine Image (AMI) used for EC2 node classes in the Helm chart. Instead of referencing a specific AMI version, the configuration now uses the latest available AMI, which will help ensure that EC2 nodes receive the most up-to-date security patches and features.

* Changed the `alias` in the `amiSelectorTerms` from a fixed version (`al2023@v20251007`) to always use the latest (`al2023@latest`) in `helm/templates/ec2nodeclass.yaml`.