### PR TITLE
feat: Expose Helm values as Terraform variables for module portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,29 @@ module "karpenter" {
 - Native SQS queue and EventBridge rules for EKS interruption handling.
 - Flexible configuration of multi-architecture NodePools and EC2NodeClasses.
 
+## Portability & Customisation
+
+This module is built for enterprise-grade portability, allowing you to pass through Helm values and configurations from Terraform to support varied environments and customer architectures.
+
+### Key Customisable Variables
+
+| Variable | Description | Default |
+| :--- | :--- | :--- |
+| `node_iam_role_name` | The name of the IAM role for Karpenter-managed EKS nodes. | `"eks-node"` |
+| `controller_resources` | Limits and requests for the Karpenter controller container. | *Standard limits (512Mi/250m)* |
+| `controller_replicas` | Number of Karpenter controller replicas to run (useful for scaling down in dev/sandboxes). | `1` |
+| `controller_node_selector` | Custom node selector map for placement of Karpenter controller pods. | `{}` |
+| `controller_tolerations` | Custom list of node tolerations for the Karpenter controller pods. | `[]` |
+| `controller_affinity` | Custom affinity rule block for Karpenter controller pods. | `{}` |
+| `subnet_selector_terms` | Custom subnet selector terms for EC2NodeClasses. Defaults to EKS auto-discovery by cluster name tags. | `null` |
+| `security_group_selector_terms` | Custom security group selector terms for EC2NodeClasses. Defaults to auto-discovery by cluster name tags. | `null` |
+| `al2023_ami_selector_terms` | Custom AMI selector terms for default AL2023 EC2NodeClasses. | `null` |
+| `bottlerocket_ami_selector_terms` | Custom AMI selector terms for default Bottlerocket EC2NodeClasses. | `null` |
+| `al2023_node_pool_weight` | Preference weight for default AL2023 nodes over Bottlerocket. | `10` |
+| `bottlerocket_node_pool_weight` | Preference weight for default Bottlerocket nodes over AL2023. | `20` |
+| `kubelet_max_pods` | Configures `maxPods` on default EC2NodeClasses (important for custom networking/CNIs). | `110` |
+| `metadata_options` | Instance metadata options (IMDSv2 settings) for EC2NodeClasses. | *Secure defaults (hop limit 2, tokens required)* |
+
 ## Changes
 
 Changes to this module are captured in the [CHANGELOG](./CHANGELOG.md).

--- a/helm/templates/ec2nodeclass.yaml
+++ b/helm/templates/ec2nodeclass.yaml
@@ -7,7 +7,21 @@ metadata:
 spec:
   amiFamily: {{ default "AL2023" $pool.amiFamily }}
   amiSelectorTerms:
-    - alias: {{ if eq (default "AL2023" $pool.amiFamily | upper) "AL2023" }}al2023@v20251007{{ else }}bottlerocket@latest{{ end }}
+    {{- if $pool.amiSelectorTerms }}
+    {{- toYaml $pool.amiSelectorTerms | nindent 4 }}
+    {{- else if eq (default "AL2023" $pool.amiFamily | upper) "AL2023" }}
+      {{- if $.Values.al2023AmiSelectorTerms }}
+      {{- toYaml $.Values.al2023AmiSelectorTerms | nindent 4 }}
+      {{- else }}
+    - alias: al2023@v20251007
+      {{- end }}
+    {{- else }}
+      {{- if $.Values.bottlerocketAmiSelectorTerms }}
+      {{- toYaml $.Values.bottlerocketAmiSelectorTerms | nindent 4 }}
+      {{- else }}
+    - alias: bottlerocket@latest
+      {{- end }}
+    {{- end }}
   blockDeviceMappings:
     {{- range $deviceName, $config := index $.Values.blockDeviceMappings (default "al2023" $pool.amiFamily | lower) }}
     - deviceName: {{ $deviceName | quote }}
@@ -17,12 +31,9 @@ spec:
         volumeType: {{ default "gp3" $config.volumeType }}
     {{- end }}
   kubelet:
-    maxPods: 110
+    maxPods: {{ default $.Values.kubeletMaxPods $pool.kubeletMaxPods }}
   metadataOptions:
-    httpEndpoint: enabled
-    httpProtocolIPv6: disabled
-    httpPutResponseHopLimit: 2 # This is changed to enable IMDS access from containers not on the host network
-    httpTokens: required
+    {{- toYaml $.Values.metadataOptions | nindent 4 }}
   {{- if eq (default "AL2023" $pool.amiFamily | upper) "AL2023" }}
   {{- if $.Values.al2023UserData }}
   userData: |-
@@ -34,13 +45,21 @@ spec:
 {{ $.Values.bottlerocketUserData | indent 4 }}
   {{- end }}
   {{- end }}
-  role: eks-node
+  role: {{ $.Values.nodeIamRoleName }}
   securityGroupSelectorTerms:
+    {{- if $.Values.securityGroupSelectorTerms }}
+    {{- toYaml $.Values.securityGroupSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ $.Values.clusterName }}
+    {{- end }}
   subnetSelectorTerms:
+    {{- if $.Values.subnetSelectorTerms }}
+    {{- toYaml $.Values.subnetSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ $.Values.clusterName }}
+    {{- end }}
 {{- end }}
 
 {{- if .Values.al2023.enabled }}
@@ -52,7 +71,11 @@ metadata:
 spec:
   amiFamily: AL2023
   amiSelectorTerms:
+    {{- if .Values.al2023AmiSelectorTerms }}
+    {{- toYaml .Values.al2023AmiSelectorTerms | nindent 4 }}
+    {{- else }}
     - alias: al2023@latest
+    {{- end }}
   blockDeviceMappings:
     {{- range $deviceName, $config := index .Values.blockDeviceMappings "al2023" }}
     - deviceName: {{ $deviceName | quote }}
@@ -62,23 +85,28 @@ spec:
         volumeType: {{ default "gp3" $config.volumeType }}
     {{- end }}
   kubelet:
-    maxPods: 110
+    maxPods: {{ .Values.kubeletMaxPods }}
   metadataOptions:
-    httpEndpoint: enabled
-    httpProtocolIPv6: disabled
-    httpPutResponseHopLimit: 2 # This is changed to enable IMDS access from containers not on the host network
-    httpTokens: required
+    {{- toYaml .Values.metadataOptions | nindent 4 }}
   {{- if .Values.al2023UserData }}
   userData: |-
 {{ .Values.al2023UserData | indent 4 }}
   {{- end }}
-  role: eks-node
+  role: {{ .Values.nodeIamRoleName }}
   securityGroupSelectorTerms:
+    {{- if .Values.securityGroupSelectorTerms }}
+    {{- toYaml .Values.securityGroupSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}
+    {{- end }}
   subnetSelectorTerms:
+    {{- if .Values.subnetSelectorTerms }}
+    {{- toYaml .Values.subnetSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}
+    {{- end }}
 {{- end }}
 
 {{- if .Values.bottlerocket.enabled }}
@@ -90,7 +118,11 @@ metadata:
 spec:
   amiFamily: Bottlerocket
   amiSelectorTerms:
+    {{- if .Values.bottlerocketAmiSelectorTerms }}
+    {{- toYaml .Values.bottlerocketAmiSelectorTerms | nindent 4 }}
+    {{- else }}
     - alias: bottlerocket@latest
+    {{- end }}
   blockDeviceMappings:
     {{- range $deviceName, $config := index .Values.blockDeviceMappings "bottlerocket" }}
     - deviceName: {{ $deviceName | quote }}
@@ -100,21 +132,26 @@ spec:
         volumeType: {{ default "gp3" $config.volumeType }}
     {{- end }}
   kubelet:
-    maxPods: 110
+    maxPods: {{ .Values.kubeletMaxPods }}
   metadataOptions:
-    httpEndpoint: enabled
-    httpProtocolIPv6: disabled
-    httpPutResponseHopLimit: 2 # This is changed to enable IMDS access from containers not on the host network
-    httpTokens: required
+    {{- toYaml .Values.metadataOptions | nindent 4 }}
   {{- if .Values.bottlerocketUserData }}
   userData: |-
 {{ .Values.bottlerocketUserData | indent 4 }}
   {{- end }}
-  role: eks-node
+  role: {{ .Values.nodeIamRoleName }}
   securityGroupSelectorTerms:
+    {{- if .Values.securityGroupSelectorTerms }}
+    {{- toYaml .Values.securityGroupSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}
+    {{- end }}
   subnetSelectorTerms:
+    {{- if .Values.subnetSelectorTerms }}
+    {{- toYaml .Values.subnetSelectorTerms | nindent 4 }}
+    {{- else }}
     - tags:
         karpenter.sh/discovery: {{ .Values.clusterName }}
+    {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,4 +41,17 @@ bottlerocket:
 al2023UserData: ""
 bottlerocketUserData: ""
 
+# Portability & customization variables
+nodeIamRoleName: eks-node
+subnetSelectorTerms: null
+securityGroupSelectorTerms: null
+al2023AmiSelectorTerms: null
+bottlerocketAmiSelectorTerms: null
+kubeletMaxPods: 110
+metadataOptions:
+  httpEndpoint: enabled
+  httpProtocolIPv6: disabled
+  httpPutResponseHopLimit: 2
+  httpTokens: required
+
 replicas: 1

--- a/iam.tf
+++ b/iam.tf
@@ -245,7 +245,7 @@ data "aws_iam_policy_document" "policy" {
     actions = [
       "iam:PassRole",
     ]
-    resources = ["arn:aws:iam::${var.aws_account_id}:role/eks-node"]
+    resources = ["arn:aws:iam::${var.aws_account_id}:role/${var.node_iam_role_name}"]
     condition {
       test     = "StringEquals"
       variable = "iam:PassedToService"

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,16 @@ resource "helm_release" "this" {
   ])
 
   values = [
-    file("${path.module}/values.yaml")
+    file("${path.module}/values.yaml"),
+    <<-EOT
+---
+replicas: ${var.controller_replicas}
+controller:
+  resources: ${jsonencode(var.controller_resources)}
+  nodeSelector: ${jsonencode(var.controller_node_selector)}
+  tolerations: ${jsonencode(var.controller_tolerations)}
+  affinity: ${jsonencode(var.controller_affinity)}
+    EOT
   ]
 }
 
@@ -114,6 +123,17 @@ ${indent(2, var.bottlerocket_userdata)}
 %{if var.block_device_mappings != ""~}
 ${var.block_device_mappings}
 %{endif~}
+
+nodeIamRoleName: ${var.node_iam_role_name}
+subnetSelectorTerms: ${jsonencode(var.subnet_selector_terms)}
+securityGroupSelectorTerms: ${jsonencode(var.security_group_selector_terms)}
+al2023AmiSelectorTerms: ${jsonencode(var.al2023_ami_selector_terms)}
+bottlerocketAmiSelectorTerms: ${jsonencode(var.bottlerocket_ami_selector_terms)}
+nodePoolWeight:
+  al2023: ${var.al2023_node_pool_weight}
+  bottlerocket: ${var.bottlerocket_node_pool_weight}
+kubeletMaxPods: ${var.kubelet_max_pods}
+metadataOptions: ${jsonencode(var.metadata_options)}
     EOT
   ]
 }

--- a/values.yaml
+++ b/values.yaml
@@ -1,11 +1,3 @@
-controller:
-  resources:
-    limits:
-      memory: 512Mi
-      cpu: 250m
-    requests:
-      memory: 256Mi
-      cpu: 250m
 # We need to use the VPC DNS resolver as CoreDNS will not be available in
 # a brand new cluster without any nodes.
 dnsPolicy: Default

--- a/variables.tf
+++ b/variables.tf
@@ -149,3 +149,102 @@ variable "karpenter_version" {
   type        = string
   default     = "1.14.0"
 }
+
+variable "node_iam_role_name" {
+  description = "The name of the IAM role for Karpenter-managed EKS nodes"
+  type        = string
+  default     = "eks-node"
+}
+
+variable "controller_resources" {
+  description = "Limits and requests for the Karpenter controller container resources"
+  type        = any
+  default = {
+    limits = {
+      cpu    = "250m"
+      memory = "512Mi"
+    }
+    requests = {
+      cpu    = "250m"
+      memory = "256Mi"
+    }
+  }
+}
+
+variable "controller_replicas" {
+  description = "Number of Karpenter controller replicas to run in the cluster"
+  type        = number
+  default     = 1
+}
+
+variable "controller_node_selector" {
+  description = "Node selector for Karpenter controller pods"
+  type        = map(string)
+  default     = {}
+}
+
+variable "controller_tolerations" {
+  description = "List of node tolerations for Karpenter controller pods"
+  type        = list(any)
+  default     = []
+}
+
+variable "controller_affinity" {
+  description = "Affinity rules for Karpenter controller pods"
+  type        = any
+  default     = {}
+}
+
+variable "subnet_selector_terms" {
+  description = "Custom subnet selector terms for the default AL2023 and Bottlerocket EC2NodeClasses. If not specified, defaults to discovery by cluster name tag."
+  type        = list(any)
+  default     = null
+}
+
+variable "security_group_selector_terms" {
+  description = "Custom security group selector terms for the default AL2023 and Bottlerocket EC2NodeClasses. If not specified, defaults to discovery by cluster name tag."
+  type        = list(any)
+  default     = null
+}
+
+variable "al2023_ami_selector_terms" {
+  description = "Custom AMI selector terms for the default AL2023 EC2NodeClass"
+  type        = list(any)
+  default     = null
+}
+
+variable "bottlerocket_ami_selector_terms" {
+  description = "Custom AMI selector terms for the default Bottlerocket EC2NodeClass"
+  type        = list(any)
+  default     = null
+}
+
+variable "al2023_node_pool_weight" {
+  description = "The preference weight assigned to the default AL2023 NodePool"
+  type        = number
+  default     = 10
+}
+
+variable "bottlerocket_node_pool_weight" {
+  description = "The preference weight assigned to the default Bottlerocket NodePool"
+  type        = number
+  default     = 20
+}
+
+variable "kubelet_max_pods" {
+  description = "Configures the default maxPods value for EKS nodes provisioned by the default NodePools"
+  type        = number
+  default     = 110
+}
+
+variable "metadata_options" {
+  description = "The instance metadata options (IMDS) configured on provisioned nodes"
+  type        = map(any)
+  default = {
+    httpEndpoint            = "enabled"
+    httpProtocolIPv6        = "disabled"
+    httpPutResponseHopLimit = 2
+    httpTokens              = "required"
+  }
+}
+


### PR DESCRIPTION
# Description

This Pull Request implements the portability improvements discussed in our assessment. It exposes key Karpenter Helm configurations and templates as customisable Terraform variables. This allows the module to be easily optimised and deployed across different environment tiers and custom customer architectures without modifying the module's core codebase.

## Key Enhancements

1. **Custom Node IAM Role (`node_iam_role_name`):** Replaced the hardcoded `"eks-node"` role name with a dynamic Terraform variable. This allows customers to pass custom IAM role names for Karpenter-provisioned nodes.
2. **Karpenter Controller Configuration:**
   - **Resources (`controller_resources`):** Exposed resource limits and requests so the controller can be scaled up/down depending on cluster size.
   - **Replicas (`controller_replicas`):** Allows configuring the controller replica count (e.g., scaling down to 1 in dev/sandbox environments).
   - **Placement (`controller_node_selector`, `controller_tolerations`, `controller_affinity`):** Ensures that the Karpenter controller can be placed on specific nodes (such as a pre-existing system node group or Fargate profile).
3. **EC2NodeClass Customisation:**
   - **Subnet & Security Group Selector Terms (`subnet_selector_terms`, `security_group_selector_terms`):** Allows customers to query subnets and SGs by tags, IDs, or custom names instead of relying on the hardcoded EKS auto-discovery tags.
   - **AMI Selector Terms (`al2023_ami_selector_terms`, `bottlerocket_ami_selector_terms`):** Enables custom or pinned AMIs instead of hardcoded versions.
   - **IMDS Metadata Options (`metadata_options`):** Allows customising instance metadata settings for enhanced security profiles.
   - **Kubelet Pod Density (`kubelet_max_pods`):** Enables customisable `maxPods` configurations.
4. **Default NodePool Weights (`al2023_node_pool_weight`, `bottlerocket_node_pool_weight`):** Exposes weights to easily toggle default provisioning preference.

## Validation Performed
- Verified all Terraform configurations format correctly.
- Added detailed customisation guide and variable table to `README.md`.
